### PR TITLE
Reload system on save.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -19,7 +19,8 @@
                  [commons-codec "1.10"]
                  [com.taoensso/timbre "4.3.1"]
                  [com.stuartsierra/component "0.3.1"]
-                 [navis/untangled-spec "0.3.5" :scope "test"]]
+                 [navis/untangled-spec "0.3.5" :scope "test"]
+                 [juxt/dirwatch "0.2.3"]]
 
   :plugins [[lein-cljsbuild "1.1.2"]
             [lein-doo "0.1.6" :exclusions [org.clojure/tools.reader]]


### PR DESCRIPTION
I built this in the in the todo-mvc because it seemed easier to test but maybe it belongs in the untangled-server?

It works pretty robustly, I was not able to break it through any combination of manual and save-triggered resets.

I did not see the point of having `dev/server` in the the set of refresh directories, nothing depends on it. Plus it was being re-`def`ed despite the `defonce` call so I removed it from the call to `set-refresh-dirs`. Alternatively we could `def` the `system` in some other namespace that will not be added to the set of refresh directories. Thoughts?

Also I used the `juxt/dirwatch` lib because it was convenient. But it's only a ~100 line wrapper around `java.nio.file`. I could reimplement it if you prefer not to add this lib as a dependency.
