### PR TITLE
updated state setup for delete todo spec

### DIFF
--- a/specs/client/untangled_todomvc/todo_spec.cljs
+++ b/specs/client/untangled_todomvc/todo_spec.cljs
@@ -92,12 +92,12 @@
       (-> @state :todos :list/filter) => :my-filter)))
 
 (specification "Delete todo"
-  (let [state (atom {:todos      [[:todo/by-id 1] [:todo/by-id 2]]
+  (let [state (atom {:todos      {:list/items [[:todo/by-id 1] [:todo/by-id 2]]}
                      :todo/by-id {1 {:id 1 :text "Hello"}
                                   2 {:id 2 :text "Bye" :completed true}}})]
 
     ((:action (m/mutate {:state state} 'todo/delete-item {:id 1})))
     (assertions
       "deletes todo from app state."
-      (:todos @state) => [[:todo/by-id 2]]
+      (-> @state :todos :list/items) => [[:todo/by-id 2]]
       (:todo/by-id @state) => {2 {:id 2 :text "Bye" :completed true}})))


### PR DESCRIPTION
The state structure for the delete todo wasn't the same as the other specs, which was causing the spec to fail.
